### PR TITLE
Add MANIFEST.in so installing by find-links from gihub works

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
-recursive-include Products *
+recursive-include src/Products *
 include *
 global-exclude *.pyc


### PR DESCRIPTION
find-links = https://github.com/koansys/Products.SimpleAttachment/archive/master.zip#egg=Products.SimpleAttachment-4.4.dev0

fails without manifest file
