### PR TITLE
Ported fileattachment view to plone 4.3

### DIFF
--- a/src/Products/SimpleAttachment/profiles/default/types/FileAttachment.xml
+++ b/src/Products/SimpleAttachment/profiles/default/types/FileAttachment.xml
@@ -15,7 +15,10 @@
  <property name="filter_content_types">False</property>
  <property name="allowed_content_types"/>
  <property name="allow_discussion">False</property>
- <alias from="(Default)" to="(dynamic view)"/>
+ <property name="default_view">fileattachment_view</property>
+ <property name="view_methods"/>
+ <property name="default_view_fallback">True</property>
+<alias from="(Default)" to="(dynamic view)"/>
  <alias from="edit" to="atct_edit"/>
  <alias from="sharing" to="@@sharing"/>
  <alias from="view" to="(selected layout)"/>

--- a/src/Products/SimpleAttachment/profiles/default/types/FileAttachment.xml
+++ b/src/Products/SimpleAttachment/profiles/default/types/FileAttachment.xml
@@ -21,7 +21,7 @@
 <alias from="(Default)" to="(dynamic view)"/>
  <alias from="edit" to="atct_edit"/>
  <alias from="sharing" to="@@sharing"/>
- <alias from="view" to="(selected layout)"/>
+ <alias from="view" to="fileattachment_view"/>
  <action title="View" action_id="view" category="object" condition_expr=""
     url_expr="string:${object_url}" visible="True">
   <permission value="View"/>

--- a/src/Products/SimpleAttachment/skins/simpleattachment/fileattachment_view.pt
+++ b/src/Products/SimpleAttachment/skins/simpleattachment/fileattachment_view.pt
@@ -9,8 +9,11 @@
     <tal:main-macro metal:define-macro="main" 
            tal:define="size python:here.getObjSize(here);
                        content_type here/content_type;
-                      ">
-        <div metal:use-macro="here/document_actions/macros/document_actions">
+                       template_id template/getId;
+                       here_url context/@@plone_context_state/object_url;
+                       portal_url context/portal_url;
+                       parent_url python:here.navigationParent(here, template_id)">
+        <div tal:replace="structure provider:plone.documentactions">
             Document actions (print, sendto etc)
         </div>
 
@@ -77,13 +80,10 @@
 
         </div>
 
-        <div metal:use-macro="here/document_relateditems/macros/relatedItems">
+        <div tal:replace="structure provider:plone.belowcontentbody">
             show related items if they exist
         </div>
     
-        <div metal:use-macro="here/document_byline/macros/byline">
-          Get the byline - contains details about author and modification date.
-        </div>
     </tal:main-macro>
 </div>
 


### PR DESCRIPTION
Hi, 

My users want absolutely to get the attachments as search results. 

So this means the view had to work in Plone4.3. The view template was present, but not activated so the site ended with traversal error.

Also the template was not up to date and used obsolete macros.

This is what I needed to do to get it working again.

I have not checked the ImageAttachment as we don't need it immediately.
